### PR TITLE
Addedd tag support to CLI

### DIFF
--- a/bin/autostacker24
+++ b/bin/autostacker24
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-
 require 'optparse'
 require 'autostacker24'
 require 'yaml'
@@ -22,12 +21,12 @@ def json?(data)
 end
 
 def load_file(path)
-  error('params file not found') unless File.exists?(path)
+  error("file #{path} not found") unless File.exists?(path)
   data = File.read(path)
   json?(data) ? JSON.parse(data) : YAML.load(data)
 end
 
-def validate_param(param)
+def validate_key_value(param)
   kv = param.split('=', 2)
   error("parameter #{param} is missing mandatory value") unless kv.size == 2
   kv
@@ -36,6 +35,8 @@ end
 args = OpenStruct.new
 args.region = ENV['AWS_REGION']
 args.params = {}
+args.tags = {}
+
 parser = OptionParser.new do |opts|
   opts.banner = 'Usage: autostacker24 command [options]'
   opts.separator ''
@@ -55,8 +56,10 @@ parser = OptionParser.new do |opts|
   opts.on('--role-arn ROLE-ARN', 'Arn of execution role')               {|v| args.role_arn = v}
   opts.on('--region REGION',     'AWS region')                          {|v| args.region = v}
   opts.on('--profile PROFILE',   'AWS profile (use aws configure)')     {|v| args.profile = v}
-  opts.on('--param KEY=VALUE',   'Stack Parameter')                     {|v| args.params.store(*validate_param(v)) }
+  opts.on('--param KEY=VALUE',   'Stack Parameter')                     {|v| args.params.store(*validate_key_value(v)) }
   opts.on('--params FILE',       'Stack Parameter from yaml/json file') {|v| args.params.merge!(load_file(v)) }
+  opts.on('--tag KEY=VALUE',     'Stack Tag')                           {|v| args.tags.store(*validate_key_value(v)) }
+  opts.on('--tags FILE',         'Stack Tags from yaml/json file')      {|v| args.tags.merge!(load_file(v)) }
   opts.on('--help',              'Show this help')                      {|_| puts opts; exit!;}
   opts.on('--version',           'Show version')                        {|_| puts `gem list autostacker24`; exit!;}
   opts.separator ''
@@ -83,7 +86,7 @@ case args.command
   when /create|update|create_or_update/
     check_template(args)
     check_stack(args)
-    Stacker.create_or_update_stack(args.stack, args.template, args.params, args.parent, args.role_arn)
+    Stacker.create_or_update_stack(args.stack, args.template, args.params, args.parent, args.role_arn, args.tags)
   when /list/
     Stacker.list_stacks()
   when /delete/
@@ -107,4 +110,3 @@ case args.command
   else
     error("unknown command '#{args.command}'")
 end
-

--- a/readme.md
+++ b/readme.md
@@ -172,3 +172,23 @@ To create or update a stack
 ```
 $ autostacker24 update --stack MyStack --template /path/to/template.yaml --region eu-west-1
 ```
+
+To create or update a stack and pass two params to template
+```
+$ autostacker24 update --stack MyStack --template /path/to/template.yaml --param myparam1=myvalue1 --param myparam2=myvalue2
+```
+
+To create or update a stack and pass params from params file (can be json or yaml)
+```
+$ autostacker24 update --stack MyStack --template /path/to/template.yaml --params /path/to/params.json
+```
+
+To create or update a stack and add two default tags to each resource
+```
+$ autostacker24 update --stack MyStack --template /path/to/template.yaml --tag mytag1=myvalue1 --tag mytag2=myvalue2
+```
+
+To create or update a stack and add tags from tags file (can be json or yaml) to each resource
+```
+$ autostacker24 update --stack MyStack --template /path/to/template.yaml --tags /path/to/tags.json
+```

--- a/spec/stacker_spec.rb
+++ b/spec/stacker_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Stacker do
           Environment: # Some Comments
             Type: String
             Default: Staging
-        EOL
+      EOL
       JSON.parse(Stacker.template_body(template))
       expect(wd).to eq(Dir.getwd())
     end
@@ -33,6 +33,25 @@ RSpec.describe Stacker do
       expect(json['Include']['File']).to eq("#!/usr/bin/env bash\necho \"bla\"")
     end
 
+    it 'should transform single tags to expected format' do
+      input = {'key1' => 'value1'}
+      expect(Stacker.transform_tags(input)).to eq([{key: 'key1', value: 'value1'}])
+    end
+
+    it 'should transform multiple tags to expected format' do
+      input = {'key1' => 'value1', 'key2' => 'value2'}
+      expect(Stacker.transform_tags(input)).to eq([{key: 'key1', value: 'value1'},{key: 'key2', value: 'value2'}])
+    end
+
+    it 'should reject nil value tags' do
+      input = {'key1' => nil}
+      expect {Stacker.transform_tags(input)}.to raise_error(RuntimeError,'key1 must not be nil')
+    end
+
+    it 'should work with empty tags' do
+      input = {}
+      expect(Stacker.transform_tags(input)).to eq([])
+    end
   end
 
 end


### PR DESCRIPTION
Hi,
I have added two new command line parameters to be able to pass tags directly from the command line.
They can be used like the already existing params and param command line options.
You can now add multiple --tag key=value params or a --tags /path/to/tags_file.json_or_yaml to the autostacker call and those tags will be passed to cloudformation.
If you want any further adjustments to the PR, please edit or just ask!
Best regards,

Christian 