### PR TITLE
fixes typo which breaks 1.8.2 build

### DIFF
--- a/lib/autostacker24/stacker.rb
+++ b/lib/autostacker24/stacker.rb
@@ -202,7 +202,7 @@ module Stacker
       params = @cloud_formation_params || {}
       params[:credentials] = @credentials if @credentials
       params[:region] = @region if @region
-      parmas[:retry_limit] = 10
+      params[:retry_limit] = 10
       @lazy_cloud_formation = Aws::CloudFormation::Client.new(params)
     end
     @lazy_cloud_formation


### PR DESCRIPTION
I updated to autostacker 1.8.2 today and the build didn't work. Heres a small fix.